### PR TITLE
Update the documentation to use wget instead of curl.

### DIFF
--- a/templates/static/instructions.html.ep
+++ b/templates/static/instructions.html.ep
@@ -56,7 +56,7 @@ get rid of this warning you have two options. You can either install the
 
 <p>
 <pre>
-curl http://debmon.org/debmon/repo.key 2>/dev/null |apt-key add - 
+wget -O - http://debmon.org/debmon/repo.key 2>/dev/null | apt-key add -
 OK
 </pre>
 </p>


### PR DESCRIPTION
curl isn't installed by default. This change updates the documentation to use wget instead.
