### PR TITLE
Sort packages within distribution

### DIFF
--- a/templates/packages/overview.html.ep
+++ b/templates/packages/overview.html.ep
@@ -12,7 +12,7 @@
 </tr>
 </thead>
 <tbody>
-% foreach my $package (keys( %{$packagedata->{$dist}} )) {
+% foreach my $package (sort(keys( %{$packagedata->{$dist}} ))) {
 <tr>
 <td><a href="<%= url_for("/packages/$dist/$package") %>">
 <%= $package %></td>


### PR DESCRIPTION
Right now the package list within a distribution is rather random on each request, sorting helps getting an overview.
